### PR TITLE
Remove deprecated include

### DIFF
--- a/include/boost/circular_buffer/details.hpp
+++ b/include/boost/circular_buffer/details.hpp
@@ -14,7 +14,6 @@
     #pragma once
 #endif
 
-#include <boost/iterator.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/container/allocator_traits.hpp>
 #include <boost/move/move.hpp>
@@ -196,7 +195,7 @@ public:
 */
 template <class Buff, class Traits>
 struct iterator :
-    public boost::iterator<
+    public std::iterator<
     std::random_access_iterator_tag,
     typename Traits::value_type,
     typename Traits::difference_type,
@@ -209,7 +208,7 @@ struct iterator :
 // Helper types
 
     //! Base iterator.
-    typedef boost::iterator<
+    typedef std::iterator<
         std::random_access_iterator_tag,
         typename Traits::value_type,
         typename Traits::difference_type,


### PR DESCRIPTION
All that boost/iterator.hpp does is pull std::iterator into namespace boost. A comment in that header mentions: "This header is obsolete and will be deprecated."