### PR TITLE
Fix error flagged by -fsanitize=nonnull-attribute

### DIFF
--- a/include/boost/circular_buffer/debug.hpp
+++ b/include/boost/circular_buffer/debug.hpp
@@ -34,7 +34,7 @@ const int UNINITIALIZED = 0xcc;
 
 template <class T>
 inline void do_fill_uninitialized_memory(T* data, std::size_t size_in_bytes) BOOST_NOEXCEPT {
-    std::memset(static_cast<void*>(data), UNINITIALIZED, size_in_bytes);
+    if (size_in_bytes != 0) std::memset(static_cast<void*>(data), UNINITIALIZED, size_in_bytes);
 }
 
 template <class T>


### PR DESCRIPTION
Summary:

this fixes the error reported by -fsanitize=nonnull-attribute analyzer:

/workdir/UnpackedTarball/boost/boost/circular_buffer/debug.hpp:37:17:
runtime error: null pointer passed as argument 1, which is declared to never be null
> /usr/include/string.h:62:62: note: nonnull attribute specified here