### PR TITLE
Inheriting std::iterator is deprecated in c++17.

### DIFF
--- a/include/boost/circular_buffer/details.hpp
+++ b/include/boost/circular_buffer/details.hpp
@@ -195,46 +195,33 @@ public:
           for iterating from begin() to end() of the circular buffer.
 */
 template <class Buff, class Traits>
-struct iterator :
-    public std::iterator<
-    std::random_access_iterator_tag,
-    typename Traits::value_type,
-    typename Traits::difference_type,
-    typename Traits::pointer,
-    typename Traits::reference>
+struct iterator
 #if BOOST_CB_ENABLE_DEBUG
-    , public debug_iterator_base
+    : public debug_iterator_base
 #endif // #if BOOST_CB_ENABLE_DEBUG
 {
 // Helper types
-
-    //! Base iterator.
-    typedef std::iterator<
-        std::random_access_iterator_tag,
-        typename Traits::value_type,
-        typename Traits::difference_type,
-        typename Traits::pointer,
-        typename Traits::reference> base_iterator;
 
     //! Non-const iterator.
     typedef iterator<Buff, typename Traits::nonconst_self> nonconst_self;
 
 // Basic types
+    typedef std::random_access_iterator_tag iterator_category;
 
     //! The type of the elements stored in the circular buffer.
-    typedef typename base_iterator::value_type value_type;
+    typedef typename Traits::value_type value_type;
 
     //! Pointer to the element.
-    typedef typename base_iterator::pointer pointer;
+    typedef typename Traits::pointer pointer;
 
     //! Reference to the element.
-    typedef typename base_iterator::reference reference;
+    typedef typename Traits::reference reference;
 
     //! Size type.
     typedef typename Traits::size_type size_type;
 
     //! Difference type.
-    typedef typename base_iterator::difference_type difference_type;
+    typedef typename Traits::difference_type difference_type;
 
 // Member variables
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -17,7 +17,6 @@
 
 #include <boost/circular_buffer.hpp>
 #include <boost/test/included/unit_test.hpp>
-#include <boost/iterator.hpp>
 #include <iterator>
 #include <numeric>
 #include <vector>
@@ -97,9 +96,9 @@ public:
 };
 
 // simulator of an input iterator
-struct MyInputIterator
-: boost::iterator<std::input_iterator_tag, int, ptrdiff_t, int*, int&> {
+struct MyInputIterator {
     typedef std::vector<int>::iterator vector_iterator;
+    typedef std::input_iterator_tag iterator_category;
     typedef int value_type;
     typedef int* pointer;
     typedef int& reference;


### PR DESCRIPTION
Boost's iterator.hpp is deprecated, too. Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>