### PR TITLE
Add serialization

### DIFF
--- a/doc/jamfile.v2
+++ b/doc/jamfile.v2
@@ -208,5 +208,12 @@ install png_install : [ glob $(here)/*.png ] : <location>$(here)/../../../doc/ht
 
 install pdfinstall : standalone : <install-type>PDF <location>. <name>circular_buffer.pdf ;
 
-
-
+###############################################################################
+alias boostdoc
+    : standalone/<format>docbook
+    :
+    :
+    : ;
+explicit boostdoc ;
+alias boostrelease ;
+explicit boostrelease ;

--- a/example/circular_buffer_bound_example.cpp
+++ b/example/circular_buffer_bound_example.cpp
@@ -11,6 +11,7 @@ This example shows how the `circular_buffer` can be utilized
 as an underlying container of the bounded buffer.
 */
 
+#include <iostream>
 #include <boost/circular_buffer.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>

--- a/example/circular_buffer_serialization.cpp
+++ b/example/circular_buffer_serialization.cpp
@@ -1,3 +1,7 @@
+// Distributed under the Boost Software License, Version 1.0.
+// (See the accompanying file LICENSE_1_0.txt
+// or a copy at <http://www.boost.org/LICENSE_1_0.txt>.)
+
 #include <boost/circular_buffer.hpp>
 #include <sstream>
 #include <iostream>

--- a/example/circular_buffer_serialization.cpp
+++ b/example/circular_buffer_serialization.cpp
@@ -1,0 +1,141 @@
+#include <boost/circular_buffer.hpp>
+#include <sstream>
+#include <iostream>
+#include <cstdlib>
+#include <random>
+#include <chrono>
+#include <fstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+
+int main(int argc, char** argv)
+{
+    int buffer_size = 100000;
+
+    if (argc == 2) {
+        buffer_size = std::atoi(argv[1]);
+        if (buffer_size <= 0) {
+            std::cout << "invalid buffer size" << std::endl;
+            return 1;
+        }
+    }
+
+    // Seed with a real random value, if available
+    std::random_device r;
+ 
+    // Choose a randomly whether to push or pop
+    std::default_random_engine e(r());
+    std::uniform_int_distribution<int> uniform_dist(1, 10);
+
+    {
+        boost::circular_buffer<double> cb1(buffer_size);
+        for (auto i = 0; i < buffer_size; ++i) {
+            auto draw = uniform_dist(e);
+            if (draw < 8 || cb1.empty())
+                cb1.push_back(i);
+            else
+                cb1.pop_front();
+        }
+
+        {
+            // in-memory storage 
+            std::stringstream ss;
+
+            boost::archive::text_oarchive oa(ss);
+            std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+            boost::serialization::serialize(oa, cb1, 0);
+            std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+            std::cout << "in-memory serialization for buffer: " << buffer_size << " took: " << 
+                std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+
+            boost::circular_buffer<double> cb2(0);
+            boost::archive::text_iarchive ia(ss);
+            begin = std::chrono::steady_clock::now();
+            boost::serialization::serialize(ia, cb2, 0);
+            end = std::chrono::steady_clock::now();
+            std::cout << "in-memory deserialization for buffer: " << buffer_size << " took: " << 
+                std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+
+            if (cb1 != cb2) {
+                std::cout << "circular buffer did not recover correctly" << std::endl;
+            }
+        }
+
+        {
+            const std::string filename = "cb.tmp";
+            // file storage
+            {
+                std::ofstream ofs(filename);
+
+                boost::archive::text_oarchive oa(ofs);
+                std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+                boost::serialization::serialize(oa, cb1, 0);
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                std::cout << "file serialization for buffer: " << buffer_size << " took: " << 
+                    std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+            }
+            {
+                std::ifstream ifs(filename);
+
+                boost::circular_buffer<double> cb2(0);
+                boost::archive::text_iarchive ia(ifs);
+                std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+                boost::serialization::serialize(ia, cb2, 0);
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                std::cout << "file deserialization for buffer: " << buffer_size << " took: " << 
+                    std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+
+                if (cb1 != cb2) {
+                    std::cout << "circular buffer did not recover correctly" << std::endl;
+                }
+            }
+            std::remove(filename.c_str());
+        }
+    }
+
+    {
+        // space optimized
+        boost::circular_buffer_space_optimized<double> cb1(buffer_size);
+        for (auto i = 0; i < buffer_size; ++i) {
+            auto draw = uniform_dist(e);
+            if (draw < 8 || cb1.empty()) {
+                cb1.push_back(i);
+            } else {
+                cb1.pop_front();
+            }
+        }
+
+        {
+            const std::string filename = "space_opt_cb.tmp";
+            {
+                std::ofstream ofs(filename);
+
+                boost::archive::text_oarchive oa(ofs);
+                std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+                boost::serialization::serialize(oa, cb1, 0);
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                std::cout << "in-memory serialization for space optimized buffer: " << buffer_size << " took: " << 
+                    std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+            }
+
+            {
+                std::ifstream ifs(filename);
+
+                boost::circular_buffer_space_optimized<double> cb2(0);
+                boost::archive::text_iarchive ia(ifs);
+                std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+                boost::serialization::serialize(ia, cb2, 0);
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                std::cout << "in-memory deserialization for space optimized buffer: " << buffer_size << " took: " << 
+                    std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count() << " usec" << std::endl;
+
+                if (cb1 != cb2) {
+                    std::cout << "space optimized circular buffer did not recover correctly" << std::endl;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+

--- a/example/jamfile.v2
+++ b/example/jamfile.v2
@@ -12,7 +12,7 @@ project
     : requirements
 			<library>/boost/system//boost_system
 			<library>/boost/thread//boost_thread
-			<library>/boost/thread/serialization
+			<library>/boost//serialization
 			#<define>BOOST_ALL_NO_LIB=1
 			<threading>multi
 

--- a/example/jamfile.v2
+++ b/example/jamfile.v2
@@ -12,7 +12,7 @@ project
     : requirements
 			<library>/boost/system//boost_system
 			<library>/boost/thread//boost_thread
-            <library>/boost/serialization
+			<library>/boost/thread/serialization
 			#<define>BOOST_ALL_NO_LIB=1
 			<threading>multi
 

--- a/example/jamfile.v2
+++ b/example/jamfile.v2
@@ -12,6 +12,7 @@ project
     : requirements
 			<library>/boost/system//boost_system
 			<library>/boost/thread//boost_thread
+            <library>/boost/serialization
 			#<define>BOOST_ALL_NO_LIB=1
 			<threading>multi
 
@@ -39,4 +40,5 @@ run bounded_buffer_comparison.cpp ;
 run circular_buffer_iter_example.cpp ;
 run circular_buffer_sum_example.cpp ;
 run circular_buffer_bound_example.cpp ../../thread/build//boost_thread ../../timer/build//boost_timer ;
+run circular_buffer_serialization.cpp ;
 

--- a/include/boost/circular_buffer.hpp
+++ b/include/boost/circular_buffer.hpp
@@ -54,6 +54,7 @@
 #include <boost/circular_buffer/details.hpp>
 #include <boost/circular_buffer/base.hpp>
 #include <boost/circular_buffer/space_optimized.hpp>
+#include <boost/circular_buffer/serialization.hpp>
 
 #undef BOOST_CB_ASSERT_TEMPLATED_ITERATOR_CONSTRUCTORS
 #undef BOOST_CB_IS_CONVERTIBLE

--- a/include/boost/circular_buffer.hpp
+++ b/include/boost/circular_buffer.hpp
@@ -54,7 +54,9 @@
 #include <boost/circular_buffer/details.hpp>
 #include <boost/circular_buffer/base.hpp>
 #include <boost/circular_buffer/space_optimized.hpp>
+#if !defined(BOOST_CIRCULAR_BUFFER_DISABLE_SERIALIZATION)
 #include <boost/circular_buffer/serialization.hpp>
+#endif
 
 #undef BOOST_CB_ASSERT_TEMPLATED_ITERATOR_CONSTRUCTORS
 #undef BOOST_CB_IS_CONVERTIBLE

--- a/include/boost/circular_buffer/serialization.hpp
+++ b/include/boost/circular_buffer/serialization.hpp
@@ -1,0 +1,75 @@
+// boost::circular_buffer serialization
+
+#include <boost/circular_buffer.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/smart_ptr/scoped_array.hpp>
+
+namespace boost { namespace serialization {
+template <class Archive, class T>
+void save(Archive& ar, const circular_buffer<T>& b, const unsigned int /* version */)
+{
+    ar << b.capacity();
+    ar << b.size();
+    const typename circular_buffer<T>::const_array_range one = b.array_one();
+    const typename circular_buffer<T>::const_array_range two = b.array_two();
+    ar.save_binary(one.first, one.second*sizeof(T));
+    ar.save_binary(two.first, two.second*sizeof(T));
+}
+
+template <class Archive, class T>
+void load(Archive& ar, circular_buffer<T>& b, const unsigned int /* version */)
+{
+    b.clear();
+    typename circular_buffer<T>::capacity_type capacity;
+    typename circular_buffer<T>::size_type size;
+    ar >> capacity;
+    ar >> size;
+    b.set_capacity(capacity);
+    const scoped_array<typename circular_buffer<T>::value_type> buff(new T[size]);
+    ar.load_binary(buff.get(), size*sizeof(T));
+    b.insert(b.begin(), buff.get(), buff.get()+size);
+}
+
+template<class Archive, class T>
+inline void serialize(Archive & ar, circular_buffer<T>& b, const unsigned int version)
+{
+    split_free(ar, b, version);
+}
+
+template <class Archive, class T>
+void save(Archive& ar, const circular_buffer_space_optimized<T>& b, const unsigned int /* version */)
+{
+    ar << b.capacity().capacity();
+    ar << b.capacity().min_capacity();
+    ar << b.size();
+    const typename circular_buffer_space_optimized<T>::const_array_range one = b.array_one();
+    const typename circular_buffer_space_optimized<T>::const_array_range two = b.array_two();
+    ar.save_binary(one.first, one.second*sizeof(T));
+    ar.save_binary(two.first, two.second*sizeof(T));
+}
+
+template <class Archive, class T>
+void load(Archive& ar, circular_buffer_space_optimized<T>& b, const unsigned int /* version */)
+{
+    b.clear();
+    typename circular_buffer_space_optimized<T>::size_type capacity;
+    typename circular_buffer_space_optimized<T>::size_type min_capacity;
+    typename circular_buffer_space_optimized<T>::size_type size;
+    ar >> capacity;
+    ar >> min_capacity;
+    ar >> size;
+    const typename circular_buffer_space_optimized<T>::capacity_type capacity_control(capacity, min_capacity);
+    b.set_capacity(capacity_control);
+    const scoped_array<typename circular_buffer_space_optimized<T>::value_type> buff(new T[size]);
+    ar.load_binary(buff.get(), size*sizeof(T));
+    b.insert(b.begin(), buff.get(), buff.get()+size);
+}
+
+template<class Archive, class T>
+inline void serialize(Archive & ar, circular_buffer_space_optimized<T>& b, const unsigned int version)
+{
+    split_free(ar, b, version);
+}
+
+} } // end namespace boost::serialization
+

--- a/include/boost/circular_buffer/serialization.hpp
+++ b/include/boost/circular_buffer/serialization.hpp
@@ -1,4 +1,8 @@
-// boost::circular_buffer serialization
+// Implementation of circular_buffer serialization
+
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/circular_buffer.hpp>
 #include <boost/serialization/split_free.hpp>

--- a/include/boost/circular_buffer/serialization.hpp
+++ b/include/boost/circular_buffer/serialization.hpp
@@ -16,8 +16,10 @@ void save(Archive& ar, const circular_buffer<T>& b, const unsigned int /* versio
 {
     ar << b.capacity();
     ar << b.size();
-    for (const auto& e : b) {
-        ar << e;
+    const typename circular_buffer<T>::const_iterator it_end = b.end();
+    typename circular_buffer<T>::const_iterator it = b.begin();
+    for (; it != it_end; ++it) {
+        ar << *it;
     }
 }
 
@@ -87,8 +89,10 @@ void save(Archive& ar, const circular_buffer_space_optimized<T>& b, const unsign
     ar << b.capacity().capacity();
     ar << b.capacity().min_capacity();
     ar << b.size();
-    for (const auto& e : b) {
-        ar << e;
+    const typename circular_buffer_space_optimized<T>::const_iterator it_end = b.end();
+    typename circular_buffer_space_optimized<T>::const_iterator it = b.begin();
+    for (; it != it_end; ++it) {
+        ar << *it;
     }
 }
 

--- a/include/boost/circular_buffer/serialization.hpp
+++ b/include/boost/circular_buffer/serialization.hpp
@@ -7,14 +7,26 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/serialization/split_free.hpp>
 #include <boost/smart_ptr/scoped_array.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 
 namespace boost { namespace serialization {
 template <class Archive, class T>
 void save(Archive& ar, const circular_buffer<T>& b, const unsigned int /* version */)
 {
     ar << b.capacity();
-    const typename circular_buffer<T>::const_array_range one = b.array_one();
-    const typename circular_buffer<T>::const_array_range two = b.array_two();
+    ar << b.size();
+    for (const auto& e : b) {
+        ar << e;
+    }
+}
+
+template <class T>
+void save(archive::binary_oarchive& ar, const circular_buffer<T>& b, const unsigned int /* version */)
+{
+    ar << b.capacity();
+    const typename circular_buffer<T>::const_array_range& one = b.array_one();
+    const typename circular_buffer<T>::const_array_range& two = b.array_two();
     ar << one.second;
     ar << two.second;
     if (one.second) {
@@ -27,6 +39,23 @@ void save(Archive& ar, const circular_buffer<T>& b, const unsigned int /* versio
 
 template <class Archive, class T>
 void load(Archive& ar, circular_buffer<T>& b, const unsigned int /* version */)
+{
+    b.clear();
+    typename circular_buffer<T>::capacity_type capacity;
+    ar >> capacity;
+    b.set_capacity(capacity);
+    typename circular_buffer<T>::size_type size;
+    ar >> size;
+    while (size > 0) {
+        T e;
+        ar >> e;
+        b.push_back(e);
+        --size;
+    }
+}
+
+template <class T>
+void load(archive::binary_iarchive& ar, circular_buffer<T>& b, const unsigned int /* version */)
 {
     b.clear();
     typename circular_buffer<T>::capacity_type capacity;
@@ -57,6 +86,17 @@ void save(Archive& ar, const circular_buffer_space_optimized<T>& b, const unsign
 {
     ar << b.capacity().capacity();
     ar << b.capacity().min_capacity();
+    ar << b.size();
+    for (const auto& e : b) {
+        ar << e;
+    }
+}
+
+template <class T>
+void save(archive::binary_oarchive& ar, const circular_buffer_space_optimized<T>& b, const unsigned int /* version */)
+{
+    ar << b.capacity().capacity();
+    ar << b.capacity().min_capacity();
     const typename circular_buffer_space_optimized<T>::const_array_range one = b.array_one();
     const typename circular_buffer_space_optimized<T>::const_array_range two = b.array_two();
     ar << one.second;
@@ -71,6 +111,26 @@ void save(Archive& ar, const circular_buffer_space_optimized<T>& b, const unsign
 
 template <class Archive, class T>
 void load(Archive& ar, circular_buffer_space_optimized<T>& b, const unsigned int /* version */)
+{
+    b.clear();
+    typename circular_buffer_space_optimized<T>::size_type capacity;
+    typename circular_buffer_space_optimized<T>::size_type min_capacity;
+    ar >> capacity;
+    ar >> min_capacity;
+    const typename circular_buffer_space_optimized<T>::capacity_type capacity_control(capacity, min_capacity);
+    b.set_capacity(capacity_control);
+    typename circular_buffer<T>::size_type size;
+    ar >> size;
+    while (size > 0) {
+        T e;
+        ar >> e;
+        b.push_back(e);
+        --size;
+    }
+}
+
+template <class T>
+void load(archive::binary_iarchive& ar, circular_buffer_space_optimized<T>& b, const unsigned int /* version */)
 {
     b.clear();
     typename circular_buffer_space_optimized<T>::size_type capacity;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,9 @@ import testing ;
 
 project
     : requirements
+      <library>/boost/test//boost_unit_test_framework
+      <library>/boost/serialization
+      <link>static
       <toolset>msvc:<warnings>all
       <toolset>msvc:<asynch-exceptions>on
       <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
@@ -29,4 +32,5 @@ test-suite "circular_buffer"
     [ run soft_iterator_invalidation.cpp : : : <threading>single : ]
     [ run constant_erase_test.cpp : : : <threading>single : ]
     [ compile bounded_buffer_comparison.cpp : <threading>multi : ]
+    [ run serialization_test.cpp : : : <threading>single : ]
   ;

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -9,11 +9,11 @@
 
 using namespace boost::unit_test;
 
-const auto buffer_size = 100000;
+const int buffer_size = 100000;
 
 void basic_test() {
     boost::circular_buffer<double> cb1(buffer_size);
-    for (auto i = 0; i < buffer_size; ++i) {
+    for (int i = 0; i < buffer_size; ++i) {
         cb1.push_back(i);
     }
 
@@ -33,7 +33,7 @@ void basic_test() {
 
 void spaced_optimized_test() {
     boost::circular_buffer_space_optimized<double> cb1(buffer_size);
-    for (auto i = 0; i < buffer_size; ++i) {
+    for (int i = 0; i < buffer_size; ++i) {
         cb1.push_back(i);
     }
 
@@ -51,7 +51,6 @@ void spaced_optimized_test() {
     }
 }
 
-
 // test main
 test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
 
@@ -62,4 +61,5 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
 
     return tests;
 }
+
 

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -15,8 +15,9 @@ using namespace boost::unit_test;
 
 const int buffer_size = 100000;
 
+template<typename buffer_type>
 void basic_test() {
-    boost::circular_buffer<double> cb1(buffer_size);
+    buffer_type cb1(buffer_size);
     for (int i = 0; i < buffer_size; ++i) {
         cb1.push_back(i);
     }
@@ -28,31 +29,35 @@ void basic_test() {
         boost::archive::text_oarchive oa(ss);
         boost::serialization::serialize(oa, cb1, 0);
 
-        boost::circular_buffer<double> cb2(0);
+        buffer_type cb2(0);
         boost::archive::text_iarchive ia(ss);
         boost::serialization::serialize(ia, cb2, 0);
         BOOST_CHECK(cb1 == cb2);
     }
 }
 
-void spaced_optimized_test() {
-    boost::circular_buffer_space_optimized<double> cb1(buffer_size);
-    for (int i = 0; i < buffer_size; ++i) {
-        cb1.push_back(i);
-    }
+template<typename buffer_type>
+void fragmented_buffer_test() {
 
-    {
-        // in-memory storage 
-        std::stringstream ss;
+    buffer_type cb1(buffer_size);
+    for (auto i = 0; i < buffer_size/4; ++i)
+        cb1.push_back(i+1);
+    for (auto i = 0; i < buffer_size/4; ++i)
+        cb1.push_front((i+1)*100);
 
-        boost::archive::text_oarchive oa(ss);
-        boost::serialization::serialize(oa, cb1, 0);
+    // making sure we are testing a fragmented buffer
+    BOOST_CHECK(!cb1.is_linearized());
 
-        boost::circular_buffer_space_optimized<double> cb2(0);
-        boost::archive::text_iarchive ia(ss);
-        boost::serialization::serialize(ia, cb2, 0);
-        BOOST_CHECK(cb1 == cb2);
-    }
+    std::stringstream ss;
+
+    boost::archive::text_oarchive oa(ss);
+    boost::serialization::serialize(oa, cb1, 0);
+
+    buffer_type cb2(0);
+    boost::archive::text_iarchive ia(ss);
+    boost::serialization::serialize(ia, cb2, 0);
+
+    BOOST_CHECK(cb1 == cb2);
 }
 
 // test main
@@ -60,10 +65,11 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
 
     test_suite* tests = BOOST_TEST_SUITE("Unit tests for circular_buffer serialization.");
 
-    tests->add(BOOST_TEST_CASE(&basic_test));
-    tests->add(BOOST_TEST_CASE(&spaced_optimized_test));
+    tests->add(BOOST_TEST_CASE(&basic_test<boost::circular_buffer<double>>));
+    tests->add(BOOST_TEST_CASE(&basic_test<boost::circular_buffer_space_optimized<double>>));
+    tests->add(BOOST_TEST_CASE(&fragmented_buffer_test<boost::circular_buffer<double>>));
+    tests->add(BOOST_TEST_CASE(&fragmented_buffer_test<boost::circular_buffer_space_optimized<double>>));
 
     return tests;
 }
-
 

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -1,5 +1,9 @@
 // Test of the circular buffer container serialization
 
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/circular_buffer.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -42,9 +42,9 @@ template<typename buffer_type, typename oarchive_type, typename iarchive_type>
 void fragmented_buffer_test() {
 
     buffer_type cb1(buffer_size);
-    for (auto i = 0; i < buffer_size/4; ++i)
+    for (int i = 0; i < buffer_size/4; ++i)
         cb1.push_back(i+1);
-    for (auto i = 0; i < buffer_size/4; ++i)
+    for (int i = 0; i < buffer_size/4; ++i)
         cb1.push_front((i+1)*100);
 
     // making sure we are testing a fragmented buffer

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -7,6 +7,8 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 #include <boost/test/unit_test.hpp>
 #include <sstream>
 #include <iostream>
@@ -15,7 +17,7 @@ using namespace boost::unit_test;
 
 const int buffer_size = 100000;
 
-template<typename buffer_type>
+template<typename buffer_type, typename oarchive_type, typename iarchive_type>
 void basic_test() {
     buffer_type cb1(buffer_size);
     for (int i = 0; i < buffer_size; ++i) {
@@ -26,17 +28,17 @@ void basic_test() {
         // in-memory storage 
         std::stringstream ss;
 
-        boost::archive::text_oarchive oa(ss);
+        oarchive_type oa(ss);
         boost::serialization::serialize(oa, cb1, 0);
 
         buffer_type cb2(0);
-        boost::archive::text_iarchive ia(ss);
+        iarchive_type ia(ss);
         boost::serialization::serialize(ia, cb2, 0);
         BOOST_CHECK(cb1 == cb2);
     }
 }
 
-template<typename buffer_type>
+template<typename buffer_type, typename oarchive_type, typename iarchive_type>
 void fragmented_buffer_test() {
 
     buffer_type cb1(buffer_size);
@@ -50,14 +52,39 @@ void fragmented_buffer_test() {
 
     std::stringstream ss;
 
-    boost::archive::text_oarchive oa(ss);
+    oarchive_type oa(ss);
     boost::serialization::serialize(oa, cb1, 0);
 
     buffer_type cb2(0);
-    boost::archive::text_iarchive ia(ss);
+    iarchive_type ia(ss);
     boost::serialization::serialize(ia, cb2, 0);
 
     BOOST_CHECK(cb1 == cb2);
+}
+
+void basic_test_text() {
+    basic_test<boost::circular_buffer<double>, boost::archive::text_oarchive, boost::archive::text_iarchive>();
+}
+void basic_test_optimized_text() {
+    basic_test<boost::circular_buffer_space_optimized<double>, boost::archive::text_oarchive, boost::archive::text_iarchive>();
+}
+void fragmented_test_text() {
+    fragmented_buffer_test<boost::circular_buffer<double>, boost::archive::text_oarchive, boost::archive::text_iarchive>();
+}
+void fragmented_test_optimized_text() {
+    fragmented_buffer_test<boost::circular_buffer_space_optimized<double>, boost::archive::text_oarchive, boost::archive::text_iarchive>();
+}
+void basic_test_binary() {
+    basic_test<boost::circular_buffer<double>, boost::archive::binary_oarchive, boost::archive::binary_iarchive>();
+}
+void basic_test_optimized_binary() {
+    basic_test<boost::circular_buffer_space_optimized<double>, boost::archive::binary_oarchive, boost::archive::binary_iarchive>();
+}
+void fragmented_test_binary() {
+    fragmented_buffer_test<boost::circular_buffer<double>, boost::archive::binary_oarchive, boost::archive::binary_iarchive>();
+}
+void fragmented_test_optimized_binary() {
+    fragmented_buffer_test<boost::circular_buffer_space_optimized<double>, boost::archive::binary_oarchive, boost::archive::binary_iarchive>();
 }
 
 // test main
@@ -65,10 +92,14 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
 
     test_suite* tests = BOOST_TEST_SUITE("Unit tests for circular_buffer serialization.");
 
-    tests->add(BOOST_TEST_CASE(&basic_test<boost::circular_buffer<double>>));
-    tests->add(BOOST_TEST_CASE(&basic_test<boost::circular_buffer_space_optimized<double>>));
-    tests->add(BOOST_TEST_CASE(&fragmented_buffer_test<boost::circular_buffer<double>>));
-    tests->add(BOOST_TEST_CASE(&fragmented_buffer_test<boost::circular_buffer_space_optimized<double>>));
+    tests->add(BOOST_TEST_CASE(&basic_test_text));
+    tests->add(BOOST_TEST_CASE(&basic_test_optimized_text));
+    tests->add(BOOST_TEST_CASE(&fragmented_test_text));
+    tests->add(BOOST_TEST_CASE(&fragmented_test_optimized_text));
+    tests->add(BOOST_TEST_CASE(&basic_test_binary));
+    tests->add(BOOST_TEST_CASE(&basic_test_optimized_binary));
+    tests->add(BOOST_TEST_CASE(&fragmented_test_binary));
+    tests->add(BOOST_TEST_CASE(&fragmented_test_optimized_binary));
 
     return tests;
 }

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -1,0 +1,65 @@
+// Test of the circular buffer container serialization
+
+#include <boost/circular_buffer.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+#include <iostream>
+
+using namespace boost::unit_test;
+
+const auto buffer_size = 100000;
+
+void basic_test() {
+    boost::circular_buffer<double> cb1(buffer_size);
+    for (auto i = 0; i < buffer_size; ++i) {
+        cb1.push_back(i);
+    }
+
+    {
+        // in-memory storage 
+        std::stringstream ss;
+
+        boost::archive::text_oarchive oa(ss);
+        boost::serialization::serialize(oa, cb1, 0);
+
+        boost::circular_buffer<double> cb2(0);
+        boost::archive::text_iarchive ia(ss);
+        boost::serialization::serialize(ia, cb2, 0);
+        BOOST_CHECK(cb1 == cb2);
+    }
+}
+
+void spaced_optimized_test() {
+    boost::circular_buffer_space_optimized<double> cb1(buffer_size);
+    for (auto i = 0; i < buffer_size; ++i) {
+        cb1.push_back(i);
+    }
+
+    {
+        // in-memory storage 
+        std::stringstream ss;
+
+        boost::archive::text_oarchive oa(ss);
+        boost::serialization::serialize(oa, cb1, 0);
+
+        boost::circular_buffer_space_optimized<double> cb2(0);
+        boost::archive::text_iarchive ia(ss);
+        boost::serialization::serialize(ia, cb2, 0);
+        BOOST_CHECK(cb1 == cb2);
+    }
+}
+
+
+// test main
+test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
+
+    test_suite* tests = BOOST_TEST_SUITE("Unit tests for circular_buffer serialization.");
+
+    tests->add(BOOST_TEST_CASE(&basic_test));
+    tests->add(BOOST_TEST_CASE(&spaced_optimized_test));
+
+    return tests;
+}
+


### PR DESCRIPTION
Adding circular buffer serialization (including the space optimized version). This is to address issue #24.
For performance reasons the serialization of the buffer itself is done in, bulk, in binary format, and not element by element.