### PR TITLE
Add .cbegin() and .cend().

### DIFF
--- a/include/boost/circular_buffer/base.hpp
+++ b/include/boost/circular_buffer/base.hpp
@@ -287,6 +287,7 @@ public:
     */
     const_iterator begin() const BOOST_NOEXCEPT { return const_iterator(this, empty() ? 0 : m_first); }
 
+    const_iterator cbegin() const BOOST_NOEXCEPT { return const_iterator(this, empty() ? 0 : m_first); }
     //! Get the const iterator pointing to the end of the <code>circular_buffer</code>.
     /*!
         \return A const random access iterator pointing to the element "one behind" the last element of the <code>
@@ -303,6 +304,7 @@ public:
     */
     const_iterator end() const BOOST_NOEXCEPT { return const_iterator(this, 0); }
 
+    const_iterator cend() const BOOST_NOEXCEPT { return const_iterator(this, 0); }
     //! Get the iterator pointing to the beginning of the "reversed" <code>circular_buffer</code>.
     /*!
         \return A reverse random access iterator pointing to the last element of the <code>circular_buffer</code>.

--- a/include/boost/circular_buffer/base.hpp
+++ b/include/boost/circular_buffer/base.hpp
@@ -287,7 +287,7 @@ public:
     */
     const_iterator begin() const BOOST_NOEXCEPT { return const_iterator(this, empty() ? 0 : m_first); }
 
-    const_iterator cbegin() const BOOST_NOEXCEPT { return const_iterator(this, empty() ? 0 : m_first); }
+    const_iterator cbegin() const BOOST_NOEXCEPT { return begin(); }
     //! Get the const iterator pointing to the end of the <code>circular_buffer</code>.
     /*!
         \return A const random access iterator pointing to the element "one behind" the last element of the <code>
@@ -304,7 +304,7 @@ public:
     */
     const_iterator end() const BOOST_NOEXCEPT { return const_iterator(this, 0); }
 
-    const_iterator cend() const BOOST_NOEXCEPT { return const_iterator(this, 0); }
+    const_iterator cend() const BOOST_NOEXCEPT { return end(); }
     //! Get the iterator pointing to the beginning of the "reversed" <code>circular_buffer</code>.
     /*!
         \return A reverse random access iterator pointing to the last element of the <code>circular_buffer</code>.

--- a/test/base_test.cpp
+++ b/test/base_test.cpp
@@ -17,6 +17,7 @@ void iterator_constructor_and_assign_test() {
 
     circular_buffer<MyInteger> cb(4, 3);
     circular_buffer<MyInteger>::iterator it = cb.begin();
+    circular_buffer<MyInteger>::const_iterator cit2 = cb.cbegin();
     circular_buffer<MyInteger>::iterator itCopy;
     itCopy = it;
     it = it;
@@ -24,12 +25,15 @@ void iterator_constructor_and_assign_test() {
     cit = it;
     circular_buffer<MyInteger>::const_iterator end1 = cb.end();
     circular_buffer<MyInteger>::const_iterator end2 = end1;
+    circular_buffer<MyInteger>::const_iterator end3 = cb.cend();
 
     BOOST_TEST(itCopy == it);
     BOOST_TEST(cit == it);
     BOOST_TEST(end1 == end2);
     BOOST_TEST(it != end1);
     BOOST_TEST(cit != end2);
+    BOOST_TEST(cit2 == it);
+    BOOST_TEST(end3 == end1);
 }
 
 void iterator_reference_test() {


### PR DESCRIPTION
The following example shows how now the code compiles with `boost::math::statistics`, but previously did not:

```cpp
#include <iostream>
#include <boost/circular_buffer.hpp>
#include <boost/math/statistics/univariate_statistics.hpp>

template<class RandomAccessContainer>
void print_container(RandomAccessContainer const & v) {
    if (v.size() == 0) {
        std::cout << "{}\n";
        return;
    }
    std::cout << "{";
    for (size_t i = 0; i < v.size() - 1; ++i) {
        std::cout << v[i] << ", ";
    }
    std::cout << v[v.size()-1] << "}\n";
    return;
}

int main() {
    boost::circular_buffer<double> v(12);
    std::cout << "v.size() = " << v.size() << "\n";
    std::cout << "v.capacity() = " << v.capacity() << "\n";
    for (size_t i = 0; i < v.capacity(); ++i) {
        v.push_back(i);
    }

    print_container(v);
    std::cout << "Mean(v) = " << boost::math::statistics::mean(v) << "\n";
    std::cout << "Variance(v) = " << boost::math::statistics::variance(v) << "\n";
    v.push_back(12);
    print_container(v);
    std::cout << "Mean(v) = " << boost::math::statistics::mean(v) << "\n";
    std::cout << "Variance(v) = " << boost::math::statistics::variance(v) << "\n";

    v.push_back(13);
    print_container(v);
    std::cout << "Mean(v) = " << boost::math::statistics::mean(v) << "\n";
    std::cout << "Variance(v) = " << boost::math::statistics::variance(v) << "\n";

}
```