### PR TITLE
Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/example/bounded_buffer_comparison.cpp
+++ b/example/bounded_buffer_comparison.cpp
@@ -233,7 +233,7 @@ void fifo_test(Buffer* buffer) {
 
     // Initialize the buffer with some values before launching producer and consumer threads.
     for (unsigned long i = QUEUE_SIZE / 2L; i > 0; --i) {
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         buffer->push_front(Buffer::value_type());
 #else
         buffer->push_front(BOOST_DEDUCED_TYPENAME Buffer::value_type());

--- a/example/circular_buffer_bound_example.cpp
+++ b/example/circular_buffer_bound_example.cpp
@@ -136,7 +136,7 @@ void fifo_test(Buffer* buffer)
     // Initialize the buffer with some values before launching producer and consumer threads.
     for (unsigned long i = queue_size / 2L; i > 0; --i)
     {
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         buffer->push_front(Buffer::value_type());
 #else
         buffer->push_front(BOOST_DEDUCED_TYPENAME Buffer::value_type());

--- a/include/boost/circular_buffer.hpp
+++ b/include/boost/circular_buffer.hpp
@@ -37,7 +37,7 @@ Includes <boost/circular_buffer/base.hpp>
 #endif
 
 /*! INTERNAL ONLY */
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x0550) || BOOST_WORKAROUND(__MWERKS__, <= 0x2407)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x0550) || BOOST_WORKAROUND(__MWERKS__, <= 0x2407)
     #define BOOST_CB_IS_CONVERTIBLE(Iterator, Type) ((void)0)
 #else
     #include <iterator>

--- a/include/boost/circular_buffer/base.hpp
+++ b/include/boost/circular_buffer/base.hpp
@@ -2519,7 +2519,7 @@ private:
     template <class Iterator>
     void initialize(Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         initialize(first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         initialize(first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());
@@ -2558,7 +2558,7 @@ private:
     template <class Iterator>
     void initialize(capacity_type buffer_capacity, Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         initialize(buffer_capacity, first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         initialize(buffer_capacity, first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());
@@ -2652,7 +2652,7 @@ private:
     template <class Iterator>
     void assign(Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         assign(first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         assign(first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());
@@ -2689,7 +2689,7 @@ private:
     template <class Iterator>
     void assign(capacity_type new_capacity, Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         assign(new_capacity, first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         assign(new_capacity, first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());
@@ -2798,7 +2798,7 @@ private:
     template <class Iterator>
     void insert(const iterator& pos, Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         insert(pos, first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         insert(pos, first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());
@@ -2889,7 +2889,7 @@ private:
     template <class Iterator>
     void rinsert(const iterator& pos, Iterator first, Iterator last, const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         rinsert(pos, first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         rinsert(pos, first, last, BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::iterator_category());

--- a/include/boost/circular_buffer/space_optimized.hpp
+++ b/include/boost/circular_buffer/space_optimized.hpp
@@ -121,7 +121,7 @@ public:<br>
     using circular_buffer<T, Alloc>::max_size;
     using circular_buffer<T, Alloc>::empty;
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     reference operator [] (size_type n) { return circular_buffer<T, Alloc>::operator[](n); }
     const_reference operator [] (size_type n) const { return circular_buffer<T, Alloc>::operator[](n); }
 #else
@@ -1598,7 +1598,7 @@ private:
     static size_type init_capacity(const capacity_type& capacity_ctrl, Iterator first, Iterator last,
         const false_type&) {
         BOOST_CB_IS_CONVERTIBLE(Iterator, value_type); // check for invalid iterator type
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         return init_capacity(capacity_ctrl, first, last, std::iterator_traits<Iterator>::iterator_category());
 #else
         return init_capacity(

--- a/test/bounded_buffer_comparison.cpp
+++ b/test/bounded_buffer_comparison.cpp
@@ -233,7 +233,7 @@ void fifo_test(Buffer* buffer) {
 
     // Initialize the buffer with some values before launching producer and consumer threads.
     for (unsigned long i = QUEUE_SIZE / 2L; i > 0; --i) {
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x581))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         buffer->push_front(Buffer::value_type());
 #else
         buffer->push_front(BOOST_DEDUCED_TYPENAME Buffer::value_type());


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.