### PR TITLE
fix deprecated-copy warnings

### DIFF
--- a/include/boost/circular_buffer/details.hpp
+++ b/include/boost/circular_buffer/details.hpp
@@ -259,7 +259,10 @@ struct iterator
 #endif // #if BOOST_CB_ENABLE_DEBUG
 
     //! Assign operator.
-    BOOST_DEFAULTED_FUNCTION(iterator& operator = (const iterator& it), {
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    iterator& operator=(const iterator&) = default;
+#else
+    iterator& operator=(const iterator& it) {
         if (this == &it)
             return *this;
 #if BOOST_CB_ENABLE_DEBUG
@@ -268,7 +271,8 @@ struct iterator
         m_buff = it.m_buff;
         m_it = it.m_it;
         return *this;
-    })
+    }
+#endif
 
 // Random access iterator methods
 

--- a/include/boost/circular_buffer/details.hpp
+++ b/include/boost/circular_buffer/details.hpp
@@ -259,7 +259,7 @@ struct iterator
 #endif // #if BOOST_CB_ENABLE_DEBUG
 
     //! Assign operator.
-    iterator& operator = (const iterator& it) {
+    BOOST_DEFAULTED_FUNCTION(iterator& operator = (const iterator& it), {
         if (this == &it)
             return *this;
 #if BOOST_CB_ENABLE_DEBUG
@@ -268,7 +268,7 @@ struct iterator
         m_buff = it.m_buff;
         m_it = it.m_it;
         return *this;
-    }
+    })
 
 // Random access iterator methods
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -71,6 +71,11 @@ class InstanceCounter {
 public:
     InstanceCounter() { increment(); }
     InstanceCounter(const InstanceCounter& y) { y.increment(); }
+    InstanceCounter& operator=(const InstanceCounter& y) {
+        decrement();
+        y.increment();
+        return *this;
+    }
     ~InstanceCounter() { decrement(); }
     static int count() { return ms_count; }
 private:
@@ -106,12 +111,9 @@ struct MyInputIterator {
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
     explicit MyInputIterator(const vector_iterator& it) : m_it(it) {}
-    MyInputIterator& operator = (const MyInputIterator& it) {
-        if (this == &it)
-            return *this;
-        m_it = it.m_it;
-        return *this;
-    }
+
+    // Default assignment operator
+
     reference operator * () const { return *m_it; }
     pointer operator -> () const { return &(operator*()); }
     MyInputIterator& operator ++ () {


### PR DESCRIPTION
This PR supersedes https://github.com/boostorg/circular_buffer/pull/30 , does less invasive changes.

Tested with `./b2 libs/circular_buffer/test/ cxxstd=2a,03,11,,17,14 "cxxflags=-Werror=deprecated-copy" toolset=gcc-9 -j4` and `./b2 libs/circular_buffer/test/ cxxstd=2a,03,11,,17,14 "cxxflags=-Werror=deprecated-copy" toolset=clang-13 -j4`. All tests pass with the proposed patch