### PR TITLE
Fix -Wdeprecated-copy

### DIFF
--- a/include/boost/circular_buffer/details.hpp
+++ b/include/boost/circular_buffer/details.hpp
@@ -258,22 +258,6 @@ struct iterator
 
 #endif // #if BOOST_CB_ENABLE_DEBUG
 
-    //! Assign operator.
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
-    iterator& operator=(const iterator&) = default;
-#else
-    iterator& operator=(const iterator& it) {
-        if (this == &it)
-            return *this;
-#if BOOST_CB_ENABLE_DEBUG
-        debug_iterator_base::operator =(it);
-#endif // #if BOOST_CB_ENABLE_DEBUG
-        m_buff = it.m_buff;
-        m_it = it.m_it;
-        return *this;
-    }
-#endif
-
 // Random access iterator methods
 
     //! Dereferencing operator.


### PR DESCRIPTION
```
boost/circular_buffer/include/boost/circular_buffer/details.hpp:263:15: error: definition of implicit copy constructor for 'iterator<boost::circular_buffer<bool>, boost::cb_details::const_traits<std::allocator<bool>>>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    iterator& operator=(const iterator&) = default;
              ^
```