### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/circular_buffer

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,27 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/circular_buffer
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/move//boost_move
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_circular_buffer ]
+    [ alias all : boost_circular_buffer example test ]
+    ;
+
+call-if : boost-library circular_buffer
+    ;

--- a/build.jam
+++ b/build.jam
@@ -17,11 +17,12 @@ constant boost_dependencies :
 
 project /boost/circular_buffer
     : common-requirements
-        <include>include
+
     ;
 
 explicit
-    [ alias boost_circular_buffer : : : : <library>$(boost_dependencies) ]
+    [ alias boost_circular_buffer : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_circular_buffer example test ]
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,23 +5,26 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/move//boost_move
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/circular_buffer
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/move//boost_move
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_circular_buffer ]
+    [ alias boost_circular_buffer : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_circular_buffer example test ]
     ;
 
 call-if : boost-library circular_buffer
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,14 +7,14 @@ import project ;
 
 project /boost/circular_buffer
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/move//boost_move
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/move//boost_move
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/circular_buffer
     : common-requirements

--- a/doc/jamfile.v2
+++ b/doc/jamfile.v2
@@ -26,9 +26,9 @@ using quickbook ;
 doxygen autodoc
    :
    #  List all the files individually (RECURSIVE=NO ).
-      [ glob ../include/circular_buffer.hpp ]
-      [ glob ../include/circular_buffer/base.hpp ]
-      [ glob ../include/circular_buffer/space_optimized.hpp ]
+      [ glob ../include/boost/circular_buffer.hpp ]
+      [ glob ../include/boost/circular_buffer/base.hpp ]
+      [ glob ../include/boost/circular_buffer/space_optimized.hpp ]
 
    :
    # Pass some setting parameters to Doxygen.

--- a/doc/jamfile.v2
+++ b/doc/jamfile.v2
@@ -6,7 +6,7 @@
 
 #  Use, modification and distribution is subject to
 #  the Boost Software License, Version 1.0.
-#  (See accompanying file LICENSE_1_0.txt 
+#  (See accompanying file LICENSE_1_0.txt
 #  or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 path-constant nav_images :  html/images/ ; # png and svg images for home, next, note, tip...
@@ -16,7 +16,7 @@ path-constant here : . ; # location of /doc folder.
 
 # echo "nav_images = " $(nav_images) ; # "nav_images = I:\boost-trunk\libs\circular_buffer\doc\html\images
 # echo "images_location = " $(images_location) ; # images_location = I:\boost-trunk\libs\circular_buffer\doc\html\images
-# echo "pdf_images_location = " $(pdf_images_location) # 
+# echo "pdf_images_location = " $(pdf_images_location) #
 import modules ;
 using auto-index ;
 using doxygen ;  # Required if you want to use Doxygen.
@@ -26,10 +26,10 @@ using quickbook ;
 doxygen autodoc
    :
    #  List all the files individually (RECURSIVE=NO ).
-      [ glob ../../../boost/circular_buffer.hpp ]
-      [ glob ../../../boost/circular_buffer/base.hpp ]
-      [ glob ../../../boost/circular_buffer/space_optimized.hpp ]
-      
+      [ glob ../include/circular_buffer.hpp ]
+      [ glob ../include/circular_buffer/base.hpp ]
+      [ glob ../include/circular_buffer/space_optimized.hpp ]
+
    :
    # Pass some setting parameters to Doxygen.
       <doxygen:param>WARNINGS=YES # Default NO, but useful to see warnings, especially in a logfile.
@@ -38,14 +38,14 @@ doxygen autodoc
       # Much better to send message to a logfile than the default stderr.
       # and make sure that there are no Doxygen errors or significant warnings in the log file.
       <doxygen:param>RECURSIVE=NO # Search recursively down .hpp and .cpp subdirectories.
-      <doxygen:param>EXTRACT_ALL=NO 
-      <doxygen:param>EXTRACT_PRIVATE=NO # NO means do not extract info about private member functions and data. 
+      <doxygen:param>EXTRACT_ALL=NO
+      <doxygen:param>EXTRACT_PRIVATE=NO # NO means do not extract info about private member functions and data.
       <doxygen:param>HIDE_UNDOC_MEMBERS=YES # Only show members that have some documentation like \param, \return ...
       <doxygen:param>MACRO_EXPANSION=YES # YES will expand all macro names in the source code (default = NO).
       <doxygen:param>EXPAND_ONLY_PREDEF=YES # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES
       # then the macro expansion is limited to the macros specified with the PREDEFINED and EXPAND_AS_DEFINED tags.
       # If EXPAND_ONLY_PREDEF tag can be used to specify a list of macro names that should be expanded (as defined).
-      # The PREDEFINED tag can be used to specify one or more macro names that are defined 
+      # The PREDEFINED tag can be used to specify one or more macro names that are defined
       # before the preprocessor is started (similar to the -D option of gcc).
       # The argument of the tag is a list of macros of the form:
       #    name or name=definition (no spaces).
@@ -78,17 +78,17 @@ doxygen autodoc
       <doxygen:param>EXCLUDE_SYMBOLS=*_throws
       # <doxygen:param>IMAGE_PATH="../images" # for circular_buffer.png
       #  See autodoxywarnings.log to check this is correct.
-     
+
       # The syntax hoops to jump through are 'interesting' for more than one PREDEFINED,
       # and to permit spaces within definitions (use double quotes).
       # Don't forget that every double quote " needs a preceding \trip character!
       # and that each trailing continuation \ needs a preceding \trip character too!
       # And finally that if more than one item is included (as here) the whole is
       # enclosed in "PREDEFINED=... ", but without a leading \.  Go figure...
-      
+
       # A grep for PREDEFINED= in jamfiles will reveal even more complex examples.
       # Boost Libraries with useful examples are: Accumulators, Interprocess, MPI, Random, Units, Expressive.
-      
+
       # Optionally, you can provide a Reference section name specific for your library, for example:
       <xsl:param>"boost.doxygen.reftitle=Boost.Circular_buffer C++ Reference"
    ;
@@ -101,7 +101,7 @@ boostbook standalone
    :
       circular_buffer
    :
-   
+
    # General settings
    # =================
    <format>html:<xsl:param>boost.root=../../../..
@@ -118,7 +118,7 @@ boostbook standalone
     <xsl:param>page.margin.outer=0.5in
     # Yes, we want graphics for admonishments:
     <xsl:param>admon.graphics=1
-  
+
     # HTML options:
     # =============
     # Use graphics icons not text for navigation:
@@ -137,27 +137,27 @@ boostbook standalone
     <format>html:<xsl:param>html.cellspacing=3 # pixels
     # Vertical spacing in table cells.
     <format>html:<xsl:param>html.cellpadding=5 # pixels
-    #  Not sure if these are right way round?  
-    
+    #  Not sure if these are right way round?
+
         <auto-index>on # Turns on index (or off).
         # Turns on (or off) index-verbose for diagnostic info (using /bin auto-index-verbose folders).
-        <auto-index-verbose>on 
-        
+        <auto-index-verbose>on
+
         <format>pdf:<auto-index-internal>off # on (or off) to use internally generated indexes.
-        
+
         <format>html:<xsl:param>index.on.type=1 # = 1 For the native stylesheets to generate multiple different indexes.
-        
-        <auto-index-script>circular_buffer.idx # Specifies the name of the script to load for circular_buffer. 
+
+        <auto-index-script>circular_buffer.idx # Specifies the name of the script to load for circular_buffer.
         <auto-index-prefix>../../.. # Will get you back up to /circular_buffer, so !scan-path "boost/circular_buffer/" is where *.hpp will be,
         # and /libs/circular_buffer for other files.
         # Without this would need !scan-path "../../../boost/circular_buffer"
-        
+
         # Used by Quickbook to invoke indexing.
     # Required by boost-trunk/doc/ see jamfile.v2 to use auto-index.
     # Choose indexing method for html:
     <format>html:<auto-index-internal>on
     <format>docbook:<auto-index-internal>on
-    
+
     # PDF Options:
     # ============
     # TOC Generation: this is needed for FOP-0.9 and later:
@@ -172,10 +172,10 @@ boostbook standalone
     <xsl:param>page.margin.inner=0.5in
     # Margin size:
     <xsl:param>page.margin.outer=0.5in
-    
+
     # Yes, we want graphics for admonishments:
     <xsl:param>admon.graphics=1
-    
+
     # Set these one for PDF generation *only*:
     # default png graphics are awful in PDF form,
     # better use SVG instead:
@@ -183,19 +183,19 @@ boostbook standalone
     #<format>pdf:<xsl:param>admon.graphics.extension=".png" # Only png images are available.
     # Don't need this, default path works OK:
     #<format>pdf:<xsl:param>admon.graphics.path=$(nav_images)/ # next, prev, note, tip ... for pdf.
-    <format>pdf:<xsl:param>use.role.for.mediaobject=1 
+    <format>pdf:<xsl:param>use.role.for.mediaobject=1
     <format>pdf:<xsl:param>preferred.mediaobject.role=print
     <format>pdf:<xsl:param>img.src.path=$(pdf_images_location)/ # graphics (diagrams) for pdf.
     <format>pdf:<xsl:param>draft.mode="no"
     <format>pdf:<xsl:param>boost.url.prefix=../../../..
-    
-    <dependency>autodoc # 
+
+    <dependency>autodoc #
     <dependency>png_install
    ;
 
 # Install (copy) the 'master' copies of all icon images (both PNG and SVG)
 # and the Boost logo from your current Boost-root
-# to the local /doc/html/images folder so that html is complete and standalone. 
+# to the local /doc/html/images folder so that html is complete and standalone.
 install png_install : [ glob $(here)/*.png ] : <location>$(here)/../../../doc/html/images ;
 
 # install pdf-install : standalone : <install-type>PDF <location>. ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -28,5 +28,5 @@ test-suite "circular_buffer"
     [ run space_optimized_test.cpp : : : <threading>single <define>"BOOST_CB_ENABLE_DEBUG=1" : space_optimized_test_dbg ]
     [ run soft_iterator_invalidation.cpp : : : <threading>single : ]
     [ run constant_erase_test.cpp : : : <threading>single : ]
-    [ compile bounded_buffer_comparison.cpp : <threading>multi : ]
+    [ compile bounded_buffer_comparison.cpp : <threading>multi <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer : ]
   ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import testing ;
 
 project
     : requirements
+      <library>/boost/circular_buffer//boost_circular_buffer
       <toolset>msvc:<warnings>all
       <toolset>msvc:<asynch-exceptions>on
       <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.