### PR TITLE
Avoid UB in debug code

### DIFF
--- a/include/boost/circular_buffer/debug.hpp
+++ b/include/boost/circular_buffer/debug.hpp
@@ -34,7 +34,8 @@ const int UNINITIALIZED = 0xcc;
 
 template <class T>
 inline void do_fill_uninitialized_memory(T* data, std::size_t size_in_bytes) BOOST_NOEXCEPT {
-    std::memset(static_cast<void*>(data), UNINITIALIZED, size_in_bytes);
+    if(size_in_bytes)
+        std::memset(static_cast<void*>(data), UNINITIALIZED, size_in_bytes);
 }
 
 template <class T>


### PR DESCRIPTION
`std::memset` calls with a nullptr argument are flagged as UB by GCC `-fsanitize=undefined`, so check the size first

See https://godbolt.org/z/Kjch8dd1d for a simple example showing the diagnostics

Fixes #39