### PR TITLE
Allow trivially destructible types use constant erase

### DIFF
--- a/include/boost/circular_buffer/base.hpp
+++ b/include/boost/circular_buffer/base.hpp
@@ -25,10 +25,10 @@
 #include <boost/core/empty_value.hpp>
 #include <boost/type_traits/is_stateless.hpp>
 #include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_scalar.hpp>
 #include <boost/type_traits/is_nothrow_move_constructible.hpp>
 #include <boost/type_traits/is_nothrow_move_assignable.hpp>
 #include <boost/type_traits/is_copy_constructible.hpp>
+#include <boost/type_traits/has_trivial_destructor.hpp>
 #include <boost/type_traits/conditional.hpp>
 #include <boost/move/adl_move_swap.hpp>
 #include <boost/move/move.hpp>
@@ -2279,7 +2279,7 @@ public:
 #if BOOST_CB_ENABLE_DEBUG
         erase_begin(n, false_type());
 #else
-        erase_begin(n, is_scalar<value_type>());
+        erase_begin(n, has_trivial_destructor<value_type>());
 #endif
     }
 
@@ -2311,7 +2311,7 @@ public:
 #if BOOST_CB_ENABLE_DEBUG
         erase_end(n, false_type());
 #else
-        erase_end(n, is_scalar<value_type>());
+        erase_end(n, has_trivial_destructor<value_type>());
 #endif
     }
 
@@ -2462,7 +2462,7 @@ private:
 #if BOOST_CB_ENABLE_DEBUG
         destroy_content(false_type());
 #else
-        destroy_content(is_scalar<value_type>());
+        destroy_content(has_trivial_destructor<value_type>());
 #endif
     }
 

--- a/test/constant_erase_test.cpp
+++ b/test/constant_erase_test.cpp
@@ -68,6 +68,31 @@ void erase_begin_test() {
     BOOST_TEST(cb3[0] == 4);
     BOOST_TEST(cb3[1] == 5);
     BOOST_TEST(cb3[2] == 6);
+
+
+    circular_buffer<MyDefaultConstructible> cb4(5);
+    cb4.push_back(1);
+    cb4.push_back(2);
+    cb4.push_back(3);
+    cb4.push_back(4);
+    cb4.push_back(5);
+    cb4.push_back(6);
+
+
+    circular_buffer<MyDefaultConstructible>::pointer p4 = &cb4[0];
+    cb4.erase_begin(5);
+    BOOST_TEST(cb4.empty());
+    BOOST_TEST(p4->m_n == 2);
+    BOOST_TEST((p4 + 1)->m_n == 3);
+    BOOST_TEST((p4 + 2)->m_n == 4);
+    BOOST_TEST((p4 + 3)->m_n == 5);
+    BOOST_TEST((p4 - 1)->m_n == 6);
+
+    cb4.push_back(10);
+    cb4.push_back(11);
+    BOOST_TEST(cb4.size() == 2);
+    BOOST_TEST(cb4[0].m_n == 10);
+    BOOST_TEST(cb4[1].m_n == 11);
 }
 
 void erase_end_test() {
@@ -127,6 +152,31 @@ void erase_end_test() {
     BOOST_TEST(cb3[0] == 2);
     BOOST_TEST(cb3[1] == 3);
     BOOST_TEST(cb3[2] == 4);
+
+
+    circular_buffer<MyDefaultConstructible> cb4(5);
+    cb4.push_back(1);
+    cb4.push_back(2);
+    cb4.push_back(3);
+    cb4.push_back(4);
+    cb4.push_back(5);
+    cb4.push_back(6);
+
+    circular_buffer<MyDefaultConstructible>::pointer p4 = &cb4[0];
+
+    cb4.erase_end(5);
+    BOOST_TEST(cb4.empty());
+    BOOST_TEST(p4->m_n == 2);
+    BOOST_TEST((p4 + 1)->m_n == 3);
+    BOOST_TEST((p4 + 2)->m_n == 4);
+    BOOST_TEST((p4 + 3)->m_n == 5);
+    BOOST_TEST((p4 - 1)->m_n == 6);
+
+    cb4.push_back(10);
+    cb4.push_back(11);
+    BOOST_TEST(cb4.size() == 2);
+    BOOST_TEST(cb4[0].m_n == 10);
+    BOOST_TEST(cb4[1].m_n == 11);
 }
 
 void clear_test() {
@@ -170,6 +220,25 @@ void clear_test() {
     cb3.clear();
 
     BOOST_TEST(cb3.empty());
+
+    circular_buffer<MyDefaultConstructible> cb4(5);
+    cb4.push_back(1);
+    cb4.push_back(2);
+    cb4.push_back(3);
+    cb4.push_back(4);
+    cb4.push_back(5);
+    cb4.push_back(6);
+
+    circular_buffer<MyDefaultConstructible>::pointer p4 = &cb4[0];
+
+    cb4.clear();
+
+    BOOST_TEST(cb4.empty());
+    BOOST_TEST(p4->m_n == 2);
+    BOOST_TEST((p4 + 1)->m_n == 3);
+    BOOST_TEST((p4 + 2)->m_n == 4);
+    BOOST_TEST((p4 + 3)->m_n == 5);
+    BOOST_TEST((p4 - 1)->m_n == 6);
 }
 
 // test main


### PR DESCRIPTION
Use `boost::has_trivial_destructor` instead of `boost::is_scalar` to determine whether constant-time erasing is enabled.
Add tests to check constant-time erasing run correctly with trivially destructible types.
Fixes #51 .