### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ target_link_libraries(boost_circular_buffer INTERFACE
     Boost::config
     Boost::core
     Boost::move
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
 )

--- a/build.jam
+++ b/build.jam
@@ -11,7 +11,6 @@ constant boost_dependencies :
     /boost/config//boost_config
     /boost/core//boost_core
     /boost/move//boost_move
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.